### PR TITLE
silence 'fatal not a git repo' message when not working in a git repo

### DIFF
--- a/tapis_cli/githelper.py
+++ b/tapis_cli/githelper.py
@@ -13,8 +13,8 @@ def get_git_revision_hash():
 
 
 def get_git_revision_short_hash():
-    return subprocess.check_output(['git', 'rev-parse', '--short',
-                                    'HEAD']).decode().strip()
+    return subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'],
+                                   stderr=subprocess.DEVNULL).decode().strip()
 
 
 def get_git_remote(name='origin'):


### PR DESCRIPTION
All tapis commands issued from outside of a git repository result in this message to stderr:

`fatal: not a git repository (or any of the parent directories): .git`

The error is non-breaking, and the command proceeds as normal.

This pull request redirects git errors to /dev/null. This feature was already implemented for `get_git_remote()`, but not for `get_git_revision_short_hash()`

(This was encountered in a pipenv with python 3.7)