### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ PyMongo
 flake8
 pycodestyle
 pyflakes
-Pygments
+Pygments>=2.4.2
 PyGithub
 pytest==4.6.5
 pytest-cov


### PR DESCRIPTION
pinning pygments version, using `Pygments==2.3.1` on wrangler caused an issue w/ loading EntryPoints