### PR TITLE
Prepend local dest dir to --exclude files

### DIFF
--- a/tapis_cli/commands/taccapis/v2/jobs/helpers/sync.py
+++ b/tapis_cli/commands/taccapis/v2/jobs/helpers/sync.py
@@ -196,6 +196,7 @@ def download(source,
         dest_dir = str(job_uuid)
     else:
         dest_dir = destination
+    excludes = [os.path.join(dest_dir, e) for e in excludes]
 
     if progress:
         print_stderr('Walking remote resource...')


### PR DESCRIPTION
Ensures that the _check_write working directory is the remote directory
root when looking for --exclude files. Issue #182.